### PR TITLE
Replaced String concatenation with parameterized logging messages

### DIFF
--- a/src/main/java/at/xirado/bean/Bean.java
+++ b/src/main/java/at/xirado/bean/Bean.java
@@ -67,7 +67,7 @@ public class Bean
             Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors(),
                     new ThreadFactoryBuilder()
                             .setNameFormat("Bean Command Thread %d")
-                            .setUncaughtExceptionHandler((t, e) -> LOGGER.error("An uncaught error occurred on the command thread-pool! (Thread " + t.getName() + ")", e))
+                            .setUncaughtExceptionHandler((t, e) -> LOGGER.error("An uncaught error occurred on the command thread-pool! (Thread {})", t.getName(), e))
                             .build());
 
     private final ScheduledExecutorService scheduledExecutor =

--- a/src/main/java/at/xirado/bean/command/slashcommands/music/BookmarkCommand.java
+++ b/src/main/java/at/xirado/bean/command/slashcommands/music/BookmarkCommand.java
@@ -259,7 +259,7 @@ public class BookmarkCommand extends SlashCommand
         }
         catch (SQLException throwables)
         {
-            LOGGER.warn("Could not get bookmarks from " + userId + "!", throwables);
+            LOGGER.warn("Could not get bookmarks from {}!", userId, throwables);
             return Collections.emptyList();
         }
     }
@@ -275,7 +275,7 @@ public class BookmarkCommand extends SlashCommand
         }
         catch (SQLException throwables)
         {
-            LOGGER.warn("Could not get bookmarks from " + userId + "!", throwables);
+            LOGGER.warn("Could not get bookmarks from {}!", userId, throwables);
             return Collections.emptyList();
         }
     }
@@ -301,7 +301,7 @@ public class BookmarkCommand extends SlashCommand
         }
         catch (SQLException ex)
         {
-            LOGGER.error("Could not check if duplicate exists! (User: " + userId + ", Term: " + name + ")", ex);
+            LOGGER.error("Could not check if duplicate exists! (User: {}, Term: {})", userId, name, ex);
             return true;
         }
     }
@@ -314,7 +314,7 @@ public class BookmarkCommand extends SlashCommand
         }
         catch (SQLException ex)
         {
-            LOGGER.error("Could not check if user " + userId + " has bookmarks!", ex);
+            LOGGER.error("Could not check if user {} has bookmarks!", userId, ex);
             return false;
         }
     }
@@ -329,7 +329,7 @@ public class BookmarkCommand extends SlashCommand
         }
         catch (SQLException ex)
         {
-            LOGGER.error("Could not add bookmark for user " + userId + "!", ex);
+            LOGGER.error("Could not add bookmark for user {}!", userId, ex);
         }
     }
 }

--- a/src/main/java/at/xirado/bean/command/slashcommands/music/PlayCommand.java
+++ b/src/main/java/at/xirado/bean/command/slashcommands/music/PlayCommand.java
@@ -314,7 +314,7 @@ public class PlayCommand extends SlashCommand
         }
         catch (SQLException throwables)
         {
-            LOGGER.warn("Could not get search history from " + userId + "!", throwables);
+            LOGGER.warn("Could not get search history from {}!", userId, throwables);
             return Collections.emptyList();
         }
     }
@@ -330,7 +330,7 @@ public class PlayCommand extends SlashCommand
         }
         catch (SQLException throwables)
         {
-            LOGGER.warn("Could not get search history from " + userId + "!", throwables);
+            LOGGER.warn("Could not get search history from {}!", userId, throwables);
             return Collections.emptyList();
         }
     }
@@ -343,7 +343,7 @@ public class PlayCommand extends SlashCommand
         }
         catch (SQLException ex)
         {
-            LOGGER.error("Could not check if duplicate exists! (User: " + userId + ", Term: " + name + ")", ex);
+            LOGGER.error("Could not check if duplicate exists! (User: {}, Term: {})", userId, name, ex);
             return true;
         }
     }
@@ -356,7 +356,7 @@ public class PlayCommand extends SlashCommand
         }
         catch (SQLException ex)
         {
-            LOGGER.error("Could not check if user " + userId + " has search entries!", ex);
+            LOGGER.error("Could not check if user {} has search entries!", userId, ex);
             return false;
         }
     }
@@ -371,7 +371,7 @@ public class PlayCommand extends SlashCommand
         }
         catch (SQLException ex)
         {
-            LOGGER.error("Could not add search entry for user " + userId + "!", ex);
+            LOGGER.error("Could not add search entry for user {}!", userId, ex);
 
         }
     }

--- a/src/main/java/at/xirado/bean/data/RankingSystem.java
+++ b/src/main/java/at/xirado/bean/data/RankingSystem.java
@@ -122,7 +122,7 @@ public class RankingSystem
         }
         catch (Exception ex)
         {
-            LOGGER.error("Could not get total xp! (guild " + guildID + ", user " + userID + ")", ex);
+            LOGGER.error("Could not get total xp! (guild {}, user {})", guildID, userID, ex);
             return -1L;
         }
     }
@@ -139,7 +139,7 @@ public class RankingSystem
         }
         catch (Exception ex)
         {
-            LOGGER.error("Could not get total xp! (guild " + guildID + ", user " + userID + ")", ex);
+            LOGGER.error("Could not get total xp! (guild {}, user {})", guildID, userID, ex);
             return -1L;
         }
     }
@@ -245,7 +245,7 @@ public class RankingSystem
         }
         catch (SQLException ex)
         {
-            LOGGER.error("Could not get user preferred wildcard background (user " + user.getIdLong() + ")", ex);
+            LOGGER.error("Could not get user preferred wildcard background (user {})", user.getIdLong(), ex);
             return "card1";
         }
     }
@@ -270,7 +270,7 @@ public class RankingSystem
         }
         catch (SQLException ex)
         {
-            LOGGER.error("Could not get user preferred wildcard background (user " + user.getIdLong() + ")", ex);
+            LOGGER.error("Could not get user preferred wildcard background (user {})", user.getIdLong(), ex);
             return "card1";
         }
     }
@@ -287,7 +287,7 @@ public class RankingSystem
         }
         catch (SQLException ex)
         {
-            LOGGER.error("Could not set user preferred wildcard background (user " + user.getIdLong() + ")", ex);
+            LOGGER.error("Could not set user preferred wildcard background (user {})", user.getIdLong(), ex);
         }
     }
 

--- a/src/main/java/at/xirado/bean/event/GuildJoinListener.java
+++ b/src/main/java/at/xirado/bean/event/GuildJoinListener.java
@@ -25,10 +25,10 @@ public class GuildJoinListener extends ListenerAdapter
         int memberCount = guild.getMemberCount();
         if (isGuildBanned(guild.getIdLong()))
         {
-            log.info("Joined banned guild " + name + " with " + memberCount + " members");
+            log.info("Joined banned guild {} with {} members", name, memberCount);
             return;
         }
-        log.info("Joined guild " + name + " with " + memberCount + " members");
+        log.info("Joined guild {} with {} members", name, memberCount);
     }
 
     @Override
@@ -39,10 +39,10 @@ public class GuildJoinListener extends ListenerAdapter
         int memberCount = guild.getMemberCount();
         if (isGuildBanned(guild.getIdLong()))
         {
-            log.info("Left banned guild " + name + " with " + memberCount + " members");
+            log.info("Left banned guild {} with {} members", name, memberCount);
             return;
         }
-        log.info("Left guild " + name + " with " + memberCount + " members");
+        log.info("Left guild {} with {} members", name, memberCount);
     }
 
     @Override
@@ -62,7 +62,7 @@ public class GuildJoinListener extends ListenerAdapter
         }
         catch (SQLException ex)
         {
-            log.error("Could not check if guild " + guildId + " is banned", ex);
+            log.error("Could not check if guild {} is banned", guildId, ex);
             return false;
         }
     }
@@ -75,7 +75,7 @@ public class GuildJoinListener extends ListenerAdapter
         }
         catch (SQLException ex)
         {
-            log.error("Could not ban guild " + guildId, ex);
+            log.error("Could not ban guild {}", guildId, ex);
         }
     }
 
@@ -87,7 +87,7 @@ public class GuildJoinListener extends ListenerAdapter
         }
         catch (SQLException ex)
         {
-            log.error("Could not unban guild " + guildId, ex);
+            log.error("Could not unban guild {}", guildId, ex);
         }
     }
 }

--- a/src/main/java/at/xirado/bean/event/JDAReadyListener.java
+++ b/src/main/java/at/xirado/bean/event/JDAReadyListener.java
@@ -35,7 +35,7 @@ public class JDAReadyListener extends ListenerAdapter
         ready = true;
         Bean.getInstance().getExecutor().submit(() ->
         {
-            LOGGER.info("Successfully started " + Bean.getInstance().getShardManager().getShards().size() + " shards!");
+            LOGGER.info("Successfully started {} shards!", Bean.getInstance().getShardManager().getShards().size());
             Bean.getInstance().getInteractionCommandHandler().initialize();
             if (Bean.getInstance().isDebug())
                 LOGGER.warn("Development mode enabled.");

--- a/src/main/java/at/xirado/bean/event/MessageDeleteListener.java
+++ b/src/main/java/at/xirado/bean/event/MessageDeleteListener.java
@@ -33,7 +33,7 @@ public class MessageDeleteListener extends ListenerAdapter
             if (player.getOpenPlayer().getMessageId() == messageId)
             {
                 player.setOpenPlayer(null);
-                LOG.info("Player for guild " + event.getGuild().getName() + " has been deleted!");
+                LOG.info("Player for guild {} has been deleted!", event.getGuild().getName());
             }
         }
     }

--- a/src/main/java/at/xirado/bean/mee6/MEE6Queue.java
+++ b/src/main/java/at/xirado/bean/mee6/MEE6Queue.java
@@ -194,7 +194,7 @@ public class MEE6Queue extends Thread
             }
             currentRequestGuildId = 0L;
             int entriesTotal = ((request.getPage()) * 100) + entries;
-            LOGGER.debug("Finished transferring xp for guild " + request.getGuildId() + "! Migrated " + entriesTotal + "users.");
+            LOGGER.debug("Finished transferring xp for guild {}! Migrated {}users.", request.getGuildId(), entriesTotal);
             Guild guild = Bean.getInstance().getShardManager().getGuildById(request.getGuildId());
             if (guild != null && entriesTotal > 1)
                 Util.sendDM(request.getAuthorId(), EmbedUtil.defaultEmbed("Hey! We'd like you to know that we have finished migrating MEE6 xp for all users on your guild **" + guild.getName() + "**! (" + entriesTotal + " Users)"));

--- a/src/main/java/at/xirado/bean/music/AudioScheduler.java
+++ b/src/main/java/at/xirado/bean/music/AudioScheduler.java
@@ -149,7 +149,7 @@ public class AudioScheduler extends PlayerEventListenerAdapter
     @Override
     public void onTrackEnd(IPlayer player, AudioTrack track, AudioTrackEndReason endReason)
     {
-        log.debug("Track " + track.getInfo().title + " stopped with reason " + endReason);
+        log.debug("Track {} stopped with reason {}", track.getInfo().title, endReason);
         if (endReason.mayStartNext)
         {
             nextTrack();
@@ -188,12 +188,12 @@ public class AudioScheduler extends PlayerEventListenerAdapter
         {
             if (friendlyException.severity != FriendlyException.Severity.COMMON)
             {
-                log.warn("(Guild: " + guildId + ") An error occurred while playing track \"" + track.getInfo().title + "\" by \"" + track.getInfo().author + "\"", exception);
+                log.warn("(Guild: {}) An error occurred while playing track \"{}\" by \"{}\"", guildId, track.getInfo().title, track.getInfo().author, exception);
             }
         }
         else
         {
-            log.warn("(Guild: " + guildId + ") An error occurred while playing track \"" + track.getInfo().title + "\" by \"" + track.getInfo().author + "\"", exception);
+            log.warn("(Guild: {}) An error occurred while playing track \"{}\" by \"{}\"", guildId, track.getInfo().title, track.getInfo().author, exception);
         }
     }
 

--- a/src/main/java/at/xirado/bean/translation/LocaleLoader.java
+++ b/src/main/java/at/xirado/bean/translation/LocaleLoader.java
@@ -54,7 +54,7 @@ public class LocaleLoader
             }
             catch (Exception e)
             {
-                log.error("Could not load locale '" + lang + "'!", e);
+                log.error("Could not load locale '{}'!", lang, e);
             }
         }
 


### PR DESCRIPTION
In a few cases String concatenation is being used instead of parameterized logging messages.

It's acceptable to use in certain scenarios if you know the logging level is *always* enabled, which most likely isn't the case for debug/info. I can undo certain changes if requested for that reason.